### PR TITLE
Support for CDH4 via maven Profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
 
     <packaging>jar</packaging>
     <version>1.0.0.0</version>
+    <properties>
+        <hbase.version>0.90.4</hbase.version>
+    </properties>
+
 
     <repositories>
         <repository>
@@ -19,11 +23,28 @@
         </repository>
     </repositories>
 
+   <profiles>
+     <profile>
+       <id>cdh4</id>
+       <properties>
+         <hadoop.version>2.0.0-cdh4.1.2</hadoop.version>
+         <hbase.version>0.92.1-cdh4.1.2</hbase.version>
+       </properties>
+       <dependencies>
+         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+         </dependency>
+       </dependencies>
+     </profile>
+   </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase</artifactId>
-            <version>0.90.4</version>
+            <version>${hbase.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -98,6 +119,13 @@
                             <artifactId>${project.artifactId}</artifactId>
                         </manifestEntries>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Hello,

Your tool seams very interesting. As we use CDH4 here for HBase stack. I modify a bit your pom.xml to also support it via maven profile.

now you can do `mvn -Pcdh4 package` to generate jar including HBase and Hadoop version used in CDH4.

As there is no tests a can just say it can connect to our platform and scan a HTable, detecting keys and columns.

Cheers,
## 

Dam
